### PR TITLE
fix/rag-model-1: 전역변수 선언은 모두 v1_API_server.py에서 하도록

### DIFF
--- a/rag_model.py
+++ b/rag_model.py
@@ -333,71 +333,34 @@ def get_next_index(directory: str, category:str, id: str, session_no: int, type_
     return max_index + 1
 
 
-###############################################################
-################ AI 퀴즈 (세션 의존성 기억) ########################
-###############################################################
-def get_question(session_no:int, id:str, type_:str,  order:str):
-    load_dotenv()
-    api_key = os.getenv("OPEN_AI_KEY")
 
-    global current_index
-
-    quiz_list = quiz_list[-5:]  # 최신 5개 퀴즈만 보관
-    txt_list = choose_txt_list(type_)
-    file_number = get_next_index(rag_output_path,"quiz", id, session_no, type_, order)
-
-    retriever = get_retriever(txt_list[order-1], current_index, api_key)
-    if type_ == "open_source":
-        rag_chain = create_open_source_rag_chain(retriever, get_llm(api_key))
-    else:
-        rag_chain = create_concept_rag_chain(retriever, get_llm(api_key))
-
-    query = concept_prompt.format(
-            context=retriever,
-            quiz_list=quiz_list,       
-        )
-    
-    response = rag_chain.invoke("퀴즈 하나를 생성해줘")
-
-    while True:  # 유사하지 않은 퀴즈가 생성될 때까지 반복
-        query = concept_prompt.format(
-            context=retriever,
-            quiz_list=quiz_list,
-        )
-        response = rag_chain.invoke("퀴즈 하나를 생성해줘")
-
-        # 생성된 퀴즈가 유사하지 않다면 반복 종료
-        if len(quiz_list) == 0 or not is_similar(response, quiz_list, 0.7):
-            break
-
-    if (type_=="open_source"):
-        discription = get_discription(response, type_, order)
-        question = ''.join([discription.content, str(response)])
-    else:
-        question = response
-    
-    if (id != ""):
-        save_file(''.join(question), f"{id}_{session_no}_{type_}_{order}_quiz_{file_number}.txt", rag_output_path)
-    
-    return ''.join(response)
 
 # txt파일로 저장된 이전에 저장된 내용을 불러오는 코드 (직접 사용 X, 다른 함수내에서 자동으로 불러와짐)
-def get_quiz_files_by_id_and_type(directory: str, id: str, type_: str) -> List[str]:
+from typing import List
+import os
+
+def get_quiz_files_by_id_type_order_and_session(directory: str, session_no: int, id: str, type_: str, order: int) -> List[str]:
     """
-    주어진 디렉토리에서 특정 id와 type_에 관련된 모든 _quiz 텍스트 파일의 내용을 리스트로 반환합니다.
+    주어진 디렉토리에서 특정 id, type_, order, session_no에 관련된 모든 _quiz 텍스트 파일의 내용을 리스트로 반환합니다.
     
     :param directory: 파일을 검색할 디렉토리 경로
     :param id: 검색할 id 값
     :param type_: 검색할 type 값
-    :return: id와 type_에 관련된 _quiz 텍스트 파일 내용들의 리스트
+    :param order: 검색할 order 값
+    :param session_no: 검색할 session_no 값
+    :return: id, type_, order, session_no에 관련된 _quiz 텍스트 파일 내용들의 리스트
     """
     quiz_contents = []
     
     # 디렉토리 내 모든 파일 탐색
     for root, _, files in os.walk(directory):
         for file in files:
-            # 파일 이름이 id와 type_에 관련된 형식인지 확인
-            if file.startswith(f"{id}_") and f"_{type_}_" in file and "_quiz" in file and file.endswith(".txt"):
+            # 파일 이름이 id, type_, order, session_no에 관련된 형식인지 확인
+            if (file.startswith(f"{id}_{session_no}_") and 
+                f"_{type_}_" in file and 
+                f"_{order}_" in file and 
+                "_quiz" in file and 
+                file.endswith(".txt")):
                 file_path = os.path.join(root, file)
                 # 파일 열어서 내용 읽기
                 with open(file_path, 'r', encoding='utf-8') as f:
@@ -406,18 +369,47 @@ def get_quiz_files_by_id_and_type(directory: str, id: str, type_: str) -> List[s
     
     return quiz_contents
 
+
 ###############################################################
 ################ AI 퀴즈 (서버 의존성 기억) ########################
 ###############################################################
 
+# RAG에서 docs를 순차적으로 읽게 하기 위한 함수 (직접 사용 X, 함수 내부에서 사용)
+def get_current_index(session_no: int, id: str, type_: str, order: int, base_path: str) -> int:
+    """
+    주어진 조건에 맞는 파일에서 current_index를 가져오고, += 5 한 값을 반환합니다.
+    만약 파일이 없다면 0을 반환합니다.
+    
+    Args:
+        session_no (int): 세션 번호
+        id (str): 사용자 ID
+        type_ (str): 퀴즈 타입
+        order (int): 순서
+        base_path (str): 파일이 저장된 기본 디렉토리 경로
 
-def get_question_language(session_no:int, id:str, type_:str,  order:str, language:str):
+    Returns:
+        int: 새로운 current_index 값
+    """
+    pattern = rf"{id}_{session_no}_{type_}_{order}_quiz_(\d+)\.txt"  # 파일명 패턴
+    max_quiz_number = 0
+
+    # base_path 디렉토리 내 파일들을 검색
+    for filename in os.listdir(base_path):
+        match = re.match(pattern, filename)
+        if match:
+            quiz_number = int(match.group(1))  # 파일명에서 quiz 숫자 추출
+            max_quiz_number = max(max_quiz_number, quiz_number)
+
+    # 새로운 current_index 값 계산 (quiz_number * 5)
+    return max_quiz_number * 5
+
+
+def get_question_language(session_no:int, id:str, type_:str,  order:int, language:str, rag_output_path:str, current_index:int):
     load_dotenv()
     api_key = os.getenv("OPEN_AI_KEY")
 
-    global current_index
-
-    quiz_list = get_quiz_files_by_id_and_type("./rag_model_output", id, type_)
+    current_index = get_current_index(session_no, id, type_, order, rag_output_path)
+    quiz_list = get_quiz_files_by_id_type_order_and_session("./rag_model_output", session_no, id, type_, order)
     # print(*quiz_list)
     txt_list = choose_txt_list(type_)
     file_number = get_next_index(rag_output_path,"quiz", id, session_no, type_, order)
@@ -464,7 +456,7 @@ def get_question_language(session_no:int, id:str, type_:str,  order:str, languag
 ######################## AI 피드백 ############################
 ###############################################################
 
-def get_feedback(session_no:str, id:str, type_:str, order:int, quiz:str, user_answer:str, language:str):
+def get_feedback(session_no:str, id:str, type_:str, order:int, quiz:str, user_answer:str, language:str, rag_output_path:str):
 
     load_dotenv()
     api_key = os.getenv("OPEN_AI_KEY")
@@ -525,14 +517,3 @@ def get_discription(quiz, type_, order):
 
     return discription
         
-
-if __name__ == '__main__':
-
-    global quiz_list
-    global current_index
-    global rag_output_path
-
-    quiz_list = []
-    current_index = 0
-    valid_type = ["dl", "ml", "llm", "python", "open_source"]
-    rag_output_path = "./rag_model_output" 

--- a/v1_API_server.py
+++ b/v1_API_server.py
@@ -213,4 +213,4 @@ async def generate_audio_endpoint(text_request: TextRequest):
 
 # 메인 함수
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8004)
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/v1_API_server.py
+++ b/v1_API_server.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, validator
-from rag_model import get_question, get_feedback, get_session_no  # rag_model.py 파일을 임포트
+from rag_model import get_feedback, get_session_no, get_question_language  # rag_model.py 파일을 임포트
 from fastapi.responses import JSONResponse
 import os
 import glob
@@ -31,11 +31,19 @@ global session_no
 global type_
 global order
 global quiz
+global quiz_list
+global current_index
+global rag_output_path
+global language
+
 
 user_id: str = "sj5black"
 session_no: int = get_session_no(user_id)
 type_: str = "python"
-order: int = 3
+order: int = 1
+rag_output_path: str = "./rag_model_output"
+current_index: int = 0
+language: str = "한국어"
 
 # FastAPI 애플리케이션 생성
 app = FastAPI()
@@ -117,7 +125,7 @@ async def generate_quiz(request: QuizRequest):
     #     raise HTTPException(status_code=400, detail="선택된 주제와 AI가 생성한 topic이 일치하지 않았습니다.")
     try:
         logger.info(f"Generating quiz for topic: {request.topic}")
-        quiz = get_question(session_no, user_id, request.topic, order)
+        quiz = get_question_language(session_no, user_id, request.topic, order, language, rag_output_path, current_index)
         return {"퀴즈": quiz}
     except ValueError as ve:
         logger.error(f"ValueError: {ve}")
@@ -131,7 +139,7 @@ async def generate_quiz(request: QuizRequest):
 async def check_answer(request: AnswerRequest):
     try:
         logger.info(f"Checking answer for context {request.user_answer}")
-        feedback = get_feedback(session_no, user_id, type_, order, quiz, request.user_answer)
+        feedback = get_feedback(session_no, user_id, type_, order, quiz, request.user_answer, current_index)
         return {"피드백": feedback}
     except ValueError as ve:
         logger.error(f"ValueError: {ve}")
@@ -205,5 +213,4 @@ async def generate_audio_endpoint(text_request: TextRequest):
 
 # 메인 함수
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
-
+    uvicorn.run(app, host="0.0.0.0", port=8004)


### PR DESCRIPTION
#### 개요

- rag_mode.py 와 API_server.py 사이의 충돌 사항을 해결한 PR입니다!
- 전역 변수 선언은 모두 API_server.py로 뺐습니다.
- @sj5black API_server 마지막 코드 부분을 Client.py 파일과 포트 번호를 맞춰서 선언했는데 안 맞춰도 실행이 제대로 되셨나요?!
-` streamlit run v1_Client.py` 실행